### PR TITLE
静态文件支持

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -70,6 +70,7 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-freemarker"
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    implementation 'net.lingala.zip4j:zip4j:2.9.1'
     implementation "com.sun.mail:jakarta.mail"
     implementation "com.google.guava:guava:$guavaVersion"
     implementation "com.upyun:java-sdk:$upyunSdkVersion"

--- a/core/src/main/java/run/halo/app/config/SwaggerConfiguration.java
+++ b/core/src/main/java/run/halo/app/config/SwaggerConfiguration.java
@@ -84,6 +84,15 @@ public class SwaggerConfiguration {
     }
 
     @Bean
+    public Docket haloPluginApi() {
+        return buildApiDocket("run.halo.app.plugin.api",
+                "run.halo.app.extensions.config",
+                "/plugins/**")
+                .securitySchemes(adminApiKeys())
+                .securityContexts(adminSecurityContext());
+    }
+
+    @Bean
     SecurityConfiguration security() {
         return SecurityConfigurationBuilder.builder()
             .clientId("halo-app-client-id")

--- a/core/src/main/java/run/halo/app/extensions/SpringPluginManager.java
+++ b/core/src/main/java/run/halo/app/extensions/SpringPluginManager.java
@@ -30,6 +30,7 @@ import run.halo.app.extensions.config.model.PluginStartingError;
 import run.halo.app.extensions.event.HaloPluginStartedEvent;
 import run.halo.app.extensions.event.HaloPluginStateChangedEvent;
 import run.halo.app.extensions.event.HaloPluginStoppedEvent;
+import run.halo.app.extensions.event.HaloPluginWebStartedEvent;
 import run.halo.app.extensions.internal.PluginRequestMappingManager;
 
 /**
@@ -367,6 +368,7 @@ public class SpringPluginManager extends DefaultPluginManager
             startedPlugins.add(pluginWrapper);
 
             applicationContext.publishEvent(new HaloPluginStartedEvent(this, pluginWrapper));
+            applicationContext.publishEvent(new HaloPluginWebStartedEvent(this, pluginWrapper));
         } catch (Exception e) {
             log.error("Unable to start plugin '{}'",
                 getPluginLabel(pluginWrapper.getDescriptor()), e);

--- a/core/src/main/java/run/halo/app/extensions/SpringPluginManager.java
+++ b/core/src/main/java/run/halo/app/extensions/SpringPluginManager.java
@@ -27,10 +27,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.lang.NonNull;
 import run.halo.app.extensions.config.model.PluginStartingError;
-import run.halo.app.extensions.event.HaloPluginStartedEvent;
-import run.halo.app.extensions.event.HaloPluginStateChangedEvent;
-import run.halo.app.extensions.event.HaloPluginStoppedEvent;
-import run.halo.app.extensions.event.HaloPluginWebStartedEvent;
+import run.halo.app.extensions.event.*;
 import run.halo.app.extensions.internal.PluginRequestMappingManager;
 
 /**
@@ -207,6 +204,7 @@ public class SpringPluginManager extends DefaultPluginManager
 
                     applicationContext.publishEvent(
                         new HaloPluginStoppedEvent(this, pluginWrapper));
+                    applicationContext.publishEvent(new HaloPluginWebStoppedEvent(this, pluginWrapper));
                     firePluginStateEvent(new PluginStateEvent(this, pluginWrapper, pluginState));
                 } catch (PluginRuntimeException e) {
                     log.error(e.getMessage(), e);
@@ -259,6 +257,7 @@ public class SpringPluginManager extends DefaultPluginManager
             startedPlugins.remove(pluginWrapper);
 
             applicationContext.publishEvent(new HaloPluginStoppedEvent(this, pluginWrapper));
+            applicationContext.publishEvent(new HaloPluginWebStoppedEvent(this, pluginWrapper));
             firePluginStateEvent(new PluginStateEvent(this, pluginWrapper, pluginState));
         } catch (Exception e) {
             log.error(e.getMessage(), e);

--- a/core/src/main/java/run/halo/app/extensions/config/PluginManagerController.java
+++ b/core/src/main/java/run/halo/app/extensions/config/PluginManagerController.java
@@ -1,30 +1,29 @@
 package run.halo.app.extensions.config;
 
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import com.google.common.collect.Maps;
 import freemarker.template.TemplateException;
 import org.apache.commons.io.output.StringBuilderWriter;
 import org.apache.commons.lang3.StringUtils;
-import org.bouncycastle.math.raw.Mod;
 import org.pf4j.PluginDescriptor;
 import org.pf4j.PluginRuntimeException;
 import org.pf4j.PluginState;
 import org.pf4j.PluginWrapper;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.view.freemarker.FreeMarkerConfig;
-import org.springframework.web.servlet.view.freemarker.FreeMarkerConfigurer;
 import run.halo.app.exception.NotFoundException;
+import run.halo.app.exception.ServiceException;
 import run.halo.app.extensions.SpringPluginManager;
 import run.halo.app.extensions.config.model.PluginInfo;
 
 import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Plugin manager controller.
@@ -103,10 +102,14 @@ public class PluginManagerController {
     }
 
     @GetMapping(value = "${halo.plugin.controller.base-path:/plugins}/web/{pluginId}/**")
-    public String web(@PathVariable String pluginId, HttpServletRequest req){
+    public String web(@PathVariable String pluginId, HttpServletRequest req) {
+        PluginWrapper plugin = pluginManager.getPlugin(pluginId);
+        if (plugin == null || PluginState.STARTED.equals(plugin.getPluginState())) {
+            throw new ServiceException(pluginId + " 插件未启动");
+        }
         var url = req.getRequestURI();
         var str = StringUtils.substringAfter(url, pluginId + "/");
-        String template = "";
+        var template = "";
         if (str.length() <= 1) {
             template = pluginId + "/index.ftl";
         } else {
@@ -116,14 +119,13 @@ public class PluginManagerController {
             }
         }
         if (StringUtils.isEmpty(template)) {
-            throw new NotFoundException("NOT FOUND");
+            throw new NotFoundException("NOT FOUND " + template);
         }
-        try {
-            StringBuilderWriter writer = new StringBuilderWriter();
+        try (var writer = new StringBuilderWriter()) {
             freeMarkerConfig.getConfiguration().getTemplate(template).process(Maps.newHashMap(), writer);
             return writer.toString();
         } catch (IOException | TemplateException e) {
-            throw new NotFoundException("NOT FOUND");
+            throw new NotFoundException("NOT FOUND " + template);
         }
     }
 

--- a/core/src/main/java/run/halo/app/extensions/config/PluginManagerController.java
+++ b/core/src/main/java/run/halo/app/extensions/config/PluginManagerController.java
@@ -104,7 +104,7 @@ public class PluginManagerController {
     @GetMapping(value = "${halo.plugin.controller.base-path:/plugins}/web/{pluginId}/**")
     public String web(@PathVariable String pluginId, HttpServletRequest req) {
         PluginWrapper plugin = pluginManager.getPlugin(pluginId);
-        if (plugin == null || PluginState.STARTED.equals(plugin.getPluginState())) {
+        if (plugin == null || !PluginState.STARTED.equals(plugin.getPluginState())) {
             throw new ServiceException(pluginId + " 插件未启动");
         }
         var url = req.getRequestURI();

--- a/core/src/main/java/run/halo/app/extensions/event/HaloPluginWebStartedEvent.java
+++ b/core/src/main/java/run/halo/app/extensions/event/HaloPluginWebStartedEvent.java
@@ -1,0 +1,21 @@
+package run.halo.app.extensions.event;
+
+import org.pf4j.PluginWrapper;
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * @author grant
+ */
+public class HaloPluginWebStartedEvent extends ApplicationEvent {
+
+    private final PluginWrapper plugin;
+
+    public HaloPluginWebStartedEvent(Object source, PluginWrapper plugin) {
+        super(source);
+        this.plugin = plugin;
+    }
+
+    public PluginWrapper getPlugin() {
+        return plugin;
+    }
+}

--- a/core/src/main/java/run/halo/app/extensions/event/HaloPluginWebStoppedEvent.java
+++ b/core/src/main/java/run/halo/app/extensions/event/HaloPluginWebStoppedEvent.java
@@ -1,0 +1,29 @@
+package run.halo.app.extensions.event;
+
+import org.pf4j.PluginState;
+import org.pf4j.PluginWrapper;
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * 19/1/2022 2:13 下午
+ * 描述：
+ *
+ * @author grant
+ */
+public class HaloPluginWebStoppedEvent extends ApplicationEvent {
+
+    private final PluginWrapper plugin;
+
+    public HaloPluginWebStoppedEvent(Object source, PluginWrapper plugin) {
+        super(source);
+        this.plugin = plugin;
+    }
+
+    public PluginWrapper getPlugin() {
+        return plugin;
+    }
+
+    public PluginState getPluginState() {
+        return plugin.getPluginState();
+    }
+}

--- a/core/src/main/java/run/halo/app/extensions/listener/PluginStateChangedListener.java
+++ b/core/src/main/java/run/halo/app/extensions/listener/PluginStateChangedListener.java
@@ -1,17 +1,9 @@
 package run.halo.app.extensions.listener;
 
-import java.io.IOException;
-import java.lang.ref.Reference;
-import java.nio.file.*;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.List;
-import java.util.Optional;
-
 import lombok.extern.slf4j.Slf4j;
 import net.lingala.zip4j.ZipFile;
 import org.pf4j.PluginManager;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
@@ -22,15 +14,20 @@ import run.halo.app.extensions.config.PluginProperties;
 import run.halo.app.extensions.event.HaloPluginStartedEvent;
 import run.halo.app.extensions.event.HaloPluginStoppedEvent;
 import run.halo.app.extensions.event.HaloPluginWebStartedEvent;
+import run.halo.app.extensions.event.HaloPluginWebStoppedEvent;
 import run.halo.app.extensions.extpoint.ExtensionPointFinder;
 import run.halo.app.extensions.registry.ExtensionClassRegistry;
 import run.halo.app.extensions.registry.ExtensionClassRegistry.ClassDescriptor;
 import run.halo.app.extensions.registry.PluginListenerRegistry;
+import run.halo.app.utils.FileUtils;
 
 import javax.annotation.Resource;
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.List;
 
 import static run.halo.app.model.support.HaloConst.FILE_SEPARATOR;
-import static run.halo.app.model.support.HaloConst.USER_HOME;
 import static run.halo.app.utils.HaloUtils.ensureSuffix;
 
 /**
@@ -72,7 +69,7 @@ public class PluginStateChangedListener {
         String pluginId = event.getPlugin().getPluginId();
         Path path = event.getPlugin().getPluginPath().toAbsolutePath();
         String targetPath = ensureSuffix(haloProperties.getWorkDir(), FILE_SEPARATOR) + "static";
-        final PathMatcher pathMatcher = FileSystems.getDefault().getPathMatcher("glob:**/plugin-"+pluginId+"-*.zip");
+        final PathMatcher pathMatcher = FileSystems.getDefault().getPathMatcher("glob:**/"+pluginId+"-*.jar");
         try {
             final Path[] sourcePath = {null};
             Files.walkFileTree(path, new SimpleFileVisitor<Path>(){
@@ -86,14 +83,24 @@ public class PluginStateChangedListener {
                 }
             });
             if (sourcePath[0] != null) {
-                new ZipFile(sourcePath[0].toFile()).extractFile("classes/static/", targetPath, pluginId);
+                new ZipFile(sourcePath[0].toFile()).extractFile("static/", targetPath, pluginId);
             }
             log.info("The plugin html deploy successfully.");
         } catch (Exception e) {
             log.error("The plugin html deploy fail.", e);
         }
+    }
 
-
+    @EventListener(HaloPluginWebStoppedEvent.class)
+    public void onPluginWebStopped(HaloPluginWebStoppedEvent event) {
+        String pluginId = event.getPlugin().getPluginId();
+        String targetPath = ensureSuffix(haloProperties.getWorkDir(), FILE_SEPARATOR) + "static" + FILE_SEPARATOR + pluginId;
+        try {
+            FileUtils.deleteFolder(Paths.get(targetPath));
+        } catch (IOException e) {
+            log.error("The plugin {} html clean error", pluginId, e);
+        }
+        log.info("Plugin html {} is stopped", event.getPlugin().getPluginId());
     }
 
     @EventListener(HaloPluginStoppedEvent.class)

--- a/core/src/main/java/run/halo/app/extensions/listener/PluginStateChangedListener.java
+++ b/core/src/main/java/run/halo/app/extensions/listener/PluginStateChangedListener.java
@@ -1,21 +1,37 @@
 package run.halo.app.extensions.listener;
 
+import java.io.IOException;
+import java.lang.ref.Reference;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
+import java.util.Optional;
+
 import lombok.extern.slf4j.Slf4j;
+import net.lingala.zip4j.ZipFile;
 import org.pf4j.PluginManager;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.EventListener;
+import run.halo.app.config.properties.HaloProperties;
 import run.halo.app.extensions.SpringPluginManager;
 import run.halo.app.extensions.config.PluginProperties;
 import run.halo.app.extensions.event.HaloPluginStartedEvent;
 import run.halo.app.extensions.event.HaloPluginStoppedEvent;
+import run.halo.app.extensions.event.HaloPluginWebStartedEvent;
 import run.halo.app.extensions.extpoint.ExtensionPointFinder;
 import run.halo.app.extensions.registry.ExtensionClassRegistry;
 import run.halo.app.extensions.registry.ExtensionClassRegistry.ClassDescriptor;
 import run.halo.app.extensions.registry.PluginListenerRegistry;
+
+import javax.annotation.Resource;
+
+import static run.halo.app.model.support.HaloConst.FILE_SEPARATOR;
+import static run.halo.app.model.support.HaloConst.USER_HOME;
+import static run.halo.app.utils.HaloUtils.ensureSuffix;
 
 /**
  * Halo plugin state changed listener for Spring Boot.
@@ -35,6 +51,9 @@ public class PluginStateChangedListener {
     @Autowired
     private PluginListenerRegistry listenerRegistry;
 
+    @Resource
+    private HaloProperties haloProperties;
+
     @EventListener(HaloPluginStartedEvent.class)
     public void onPluginStarted(HaloPluginStartedEvent event) {
         String pluginId = event.getPlugin().getPluginId();
@@ -46,6 +65,35 @@ public class PluginStateChangedListener {
 
         this.extensionPointFinder.refreshExtensions();
         log.info("The plugin starts successfully.");
+    }
+
+    @EventListener(HaloPluginWebStartedEvent.class)
+    public void onPluginWebStarted(HaloPluginWebStartedEvent event) {
+        String pluginId = event.getPlugin().getPluginId();
+        Path path = event.getPlugin().getPluginPath().toAbsolutePath();
+        String targetPath = ensureSuffix(haloProperties.getWorkDir(), FILE_SEPARATOR) + "static";
+        final PathMatcher pathMatcher = FileSystems.getDefault().getPathMatcher("glob:**/plugin-"+pluginId+"-*.zip");
+        try {
+            final Path[] sourcePath = {null};
+            Files.walkFileTree(path, new SimpleFileVisitor<Path>(){
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    if (pathMatcher.matches(file)) {
+                        sourcePath[0] = file;
+                        return FileVisitResult.CONTINUE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+            if (sourcePath[0] != null) {
+                new ZipFile(sourcePath[0].toFile()).extractFile("classes/static/", targetPath, pluginId);
+            }
+            log.info("The plugin html deploy successfully.");
+        } catch (Exception e) {
+            log.error("The plugin html deploy fail.", e);
+        }
+
+
     }
 
     @EventListener(HaloPluginStoppedEvent.class)

--- a/core/src/main/resources/application.yaml
+++ b/core/src/main/resources/application.yaml
@@ -41,6 +41,7 @@ spring:
     template-loader-path:
       - file:///${halo.work-dir}/templates/
       - classpath:/templates/
+      - file:///${halo.work-dir}/static/
     expose-spring-macro-helpers: false
 management:
   endpoints:

--- a/core/src/test/java/run/halo/app/FileViewerTest.java
+++ b/core/src/test/java/run/halo/app/FileViewerTest.java
@@ -1,0 +1,26 @@
+package run.halo.app;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+
+public class FileViewerTest {
+    public static void main(String[] args) throws IOException {
+//        String file = "F:\\IT\\Code\\halo-plugin-experimental\\build\\plugins\\plugin-potatoes-1.0-SNAPSHOT.zip";
+//        ZipFile zipFile = new ZipFile(file);
+//        new ZipFile(file).extractFile("classes/static/", "E:\\tmp","cc");
+        String file = "F:\\IT\\Code\\halo-plugin-experimental\\plugins\\potatoes";
+        final PathMatcher pathMatcher = FileSystems.getDefault().getPathMatcher("glob:**/plugin-*.zip");
+        Path path = Files.walkFileTree(Paths.get(file), new SimpleFileVisitor<Path>(){
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                if (pathMatcher.matches(file)) {
+                    System.out.println(file);
+                    return FileVisitResult.CONTINUE;
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+        System.out.println(path.getFileName());
+    }
+}

--- a/plugins/potatoes/build.gradle
+++ b/plugins/potatoes/build.gradle
@@ -31,17 +31,17 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
 }
 
-defaultTasks 'zipStatic'
-
-task zipStatic(type: Zip) {
-    from 'src/main/resources/static/'
-    include '*'
-    include '*/*'
-    archiveName 'webpkg.zip'
-    destinationDir(file('build/resources/main'))
-}
-
-processResources.finalizedBy(zipStatic)
+//defaultTasks 'zipStatic'
+//
+//task zipStatic(type: Zip) {
+//    from 'src/main/resources/static/'
+//    include '*'
+//    include '*/*'
+//    archiveName 'webpkg.zip'
+//    destinationDir(file('build/resources/main'))
+//}
+//
+//processResources.finalizedBy(zipStatic)
 
 
 test {

--- a/plugins/potatoes/build.gradle
+++ b/plugins/potatoes/build.gradle
@@ -31,6 +31,19 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
 }
 
+defaultTasks 'zipStatic'
+
+task zipStatic(type: Zip) {
+    from 'src/main/resources/static/'
+    include '*'
+    include '*/*'
+    archiveName 'webpkg.zip'
+    destinationDir(file('build/resources/main'))
+}
+
+processResources.finalizedBy(zipStatic)
+
+
 test {
     useJUnitPlatform()
 }

--- a/plugins/potatoes/src/main/java/xyz/guqing/plugin/potatoes/HaloPlugin.java
+++ b/plugins/potatoes/src/main/java/xyz/guqing/plugin/potatoes/HaloPlugin.java
@@ -1,11 +1,7 @@
 package xyz.guqing.plugin.potatoes;
 
-import java.util.stream.Collectors;
 import org.pf4j.Extension;
-import org.springframework.beans.factory.annotation.Autowired;
 import run.halo.app.extensions.extpoint.IHaloPlugin;
-import run.halo.app.model.entity.Post;
-import run.halo.app.service.PostService;
 
 /**
  * @author guqing

--- a/plugins/potatoes/src/main/resources/static/abc/index.ftl
+++ b/plugins/potatoes/src/main/resources/static/abc/index.ftl
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <title>Index</title>
+</head>
+<div>
+    <p>Index abc</p>
+</div>
+</html>

--- a/plugins/potatoes/src/main/resources/static/index.ftl
+++ b/plugins/potatoes/src/main/resources/static/index.ftl
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <title>Index</title>
+</head>
+<div>
+    <p>Index</p>
+</div>
+</html>


### PR DESCRIPTION
**测试流程**
以potatoes 项目为例，在resources/static 新增需要的js、css、flt等静态资源。并build（打包）
1. 将 potatoes-1.0-SNAPSHOT-plain.jar 放入plugins插件加载目录
2. halo 主程序启动后，当PluginManagerController#start 接口被调用，会将jar里面的resources/static 所有资源复制到 ${user.home}/halo-dev/static/{pluginId} 目录下
3. 访问 **${halo.plugin.controller.base-path:/plugins}/web/{pluginId}/** ，就能正常访问静态资源

**本地调试**

1. core 主程序会加载工程目录 plugins/potatoes 下{pluginId}-*.jar ，将resources/static资源进行复制